### PR TITLE
Implement simple CI checks

### DIFF
--- a/.github/check.py
+++ b/.github/check.py
@@ -1,0 +1,44 @@
+"""
+Script that checks that no .bin/.hex files are missing and that these files 
+have matching content.
+"""
+from pathlib import Path
+import sys
+
+bin_files = []
+hex_files = []
+for filename in Path(".").iterdir():
+    if filename.suffix == ".bin":
+        bin_files.append(filename.stem)
+    elif filename.suffix == ".hex":
+        hex_files.append(filename.stem)
+
+
+error = False
+bin_files.sort()
+hex_files.sort()
+
+if bin_files != hex_files:
+    # check for .bin files without corresponding .hex files
+    for bin_file in bin_files:
+        if bin_file not in hex_files:
+            print("Missing .hex file for `{}`.".format(bin_file+".bin"), file=sys.stderr)
+            error = True
+    # check for .hex files without corresponding .bin files
+    for hex_file in hex_files:
+        if hex_file not in bin_files:
+            print("Missing .bin file for `{}`.".format(hex_file+".hex"), file=sys.stderr)
+            error = True
+
+# check that hex and bin files contain matching 
+for filename in bin_files:
+    if filename not in hex_files:
+        continue
+    bin_bytes = Path(filename+".bin").read_bytes()
+    hex_bytes = bytes.fromhex(Path(filename+".hex").read_text())
+    if bin_bytes != hex_bytes:
+        print(f"Content mismatch for {filename}.[hex/bin]:\n    bin: {bin_bytes.hex()}\n    hex: {hex_bytes.hex()}", file=sys.stderr)
+        error = True
+
+if error:
+    sys.exit(1)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,14 @@
+on: [push, pull_request]
+
+name: CI
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    name: Check
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+      
+      - name: Consistency checks
+        run: python3 .github/check.py


### PR DESCRIPTION
I wrote a simple script that checks that for each .hex/.bin file, there's also a corresponding .bin/.hex one. I set up a minimal action such that the checks will be executed on commits and PRs. This should make it easier to see whether new contributions are consistent. 

Let me know what you think!